### PR TITLE
in order to deal with parsing errors and make sure we don't miss them…

### DIFF
--- a/Xcode-Extension/CastCommand.swift
+++ b/Xcode-Extension/CastCommand.swift
@@ -161,6 +161,7 @@ struct VarInfo {
                 output.append("\(editor.indentationString(level: 2))} else {")
                 if Defaults.useLogger && !disableHouzzzLogging {
                     output.append("\(editor.indentationString(level: 3))LogError(\"Error: \(className).\(name) failed init\")")
+                    output.append("\(editor.indentationString(level: 3))assert(false, \"Please open API ticket if needed\")")
                 }
                 output.append("\(editor.indentationString(level: 3))return nil")
                 output.append("\(editor.indentationString(level: 2))}")


### PR DESCRIPTION
… on debug sessions we want to add an assert after a failed init and suggesting to open an API ticket if needed