### PR TITLE
ZCode fixes

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Houzz. All rights reserved.
 //
 
-version = 4.0.10
+version = 4.0.11
 build = 74
 
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Zcode is an Xcode plugin designed to prevent human errors when implementing mult
 ## Installation
 
 1. Download latest *Zcode* package from the [Releases](https://github.com/Houzz/Zcode/releases).
-1. Copy *Zcode* to your *Applications* folder.
-1. Launch *Zcode* once. You can close it immediately afterwards.
-1. Go to <kbd>System Preferences</kbd> > <kbd>Extensions</kbd> > <kbd>Xcode Source Editor</kbd> > select <kbd>Zcode</kbd>
-
+2. Copy *Zcode* to your *Applications* folder.
+3. Launch *Zcode* once. You can close it immediately afterwards.
+4. Go to <kbd>System Preferences</kbd> > <kbd>Extensions</kbd> > <kbd>Xcode Source Editor</kbd> > select <kbd>Zcode</kbd>
+Note: If you trying to upgrade/downgrade ZCode and your XCode doesn't pick it from the Applications folder, it means there are other instances of Zcode somewhere on your mac. Run "pluginkit -m -A -v | grep com.houzz.Zcode" and remove them.
 ## Features
 
 ### Generate: Assert IBOutlets

--- a/Xcode-Extension/CastCommand.swift
+++ b/Xcode-Extension/CastCommand.swift
@@ -371,7 +371,7 @@ class ParseInfo {
                 let dName = (idx == 0) ? "dict" : "dict\(idx)"
                 if idx == keys.count - 1 {
                     if variable.isMsec && variable.optional {
-                        output.append("\(editor.indentationString(level: 2))if let \(variable.name) = \(variable.name) {")
+                        output.append("\(editor.indentationString(level: 2))if let \(variable.name) {")
                         output.append("\(editor.indentationString(level: 3))\(dName)[\"\(key)\"] = Int(\(variable.name).timeIntervalSince1970 * 1000)")
                         output.append("\(editor.indentationString(level: 2))}")
                     } else {

--- a/Xcode-Extension/CodableCommand.swift
+++ b/Xcode-Extension/CodableCommand.swift
@@ -92,7 +92,8 @@ extension ParseInfo {
             variable.key.forEach { $0.split(separator: "/").forEach { word in allKeys.insert(String(word)) } }
         }
         for key in allKeys.sorted() {
-            output.append("\(editor.indentationString(level: 2))case \(key)")
+            let keyCorrect = key == "extension" ? "`extension`" : key
+            output.append("\(editor.indentationString(level: 2))case \(keyCorrect)")
         }
         output.append("\(editor.indentationString(level: 2))\(startReadCustomPattern)")
         if let customLines = customLines {

--- a/Xcode-Extension/CodableCommand.swift
+++ b/Xcode-Extension/CodableCommand.swift
@@ -50,40 +50,27 @@ fileprivate extension VarInfo {
         return output.joined(separator: " ")
     }
     
-//    func encodeStatement() -> String {
-//        var collect: String = ""
-//        let items = key[0].split(separator: "/")
-//        var currentContainer: String = "container"
-//        for (idx,single) in items.enumerated() {
-//            if idx == items.count - 1 {
-//                switch type {
-//                case "URL", "UIImage", "UIColor":
-//                    collect += "\(currentContainer).encode\(type)\(optional ? "IfPresent": "")(\(name), forKey: .\(single))"
-//                default:
-//                    collect +=  "\(currentContainer).encode\(optional ? "IfPregesent": "")(\(name), forKey: .\(single))"
-//                }
-//            } else {
-//                var collect = "var \(single.lowercased())Container = \(currentContainer)"
-//                collect += ".nestedContainer(keyedBy: CodingKeys.self, forKey: .\(single))\n"
-//                currentContainer = single.lowercased()
-//            }
-//        }
-//        return collect
-//    }
-    
-    func encodeStatement() -> String {
-        var collect = "try container"
+    func encodeStatements() -> [String] {
+        var collect: [String] = []
         let items = key[0].split(separator: "/")
+        var currentContainer: String = "container"
+        
         for (idx,single) in items.enumerated() {
-            if idx < items.count - 1 {
-                collect += ".nestedContainer(keyedBy: CodingKeys.self, forKey: .\(single))"
-            } else {
+            if idx == items.count - 1 {
                 switch type {
                 case "URL", "UIImage", "UIColor":
-                    collect += ".encode\(type)\(optional ? "IfPresent": "")(\(name), forKey: .\(single))"
+                    collect.append("try \(currentContainer).encode\(type)\(optional ? "IfPresent": "")(\(name), forKey: .\(single))")
                 default:
-                    collect +=  ".encode\(optional ? "IfPresent": "")(\(name), forKey: .\(single))"
+                    collect.append("try \(currentContainer).encode\(optional ? "IfPresent": "")(\(name), forKey: .\(single))")
                 }
+            } else {
+                let lowercasedFirstLetterSingle = single.prefix(1).lowercased() + single.dropFirst()
+                let uppercasedFirstLetterCurrent = currentContainer.prefix(1).uppercased() + currentContainer.dropFirst()
+                let nextContainer = "\(lowercasedFirstLetterSingle)\(uppercasedFirstLetterCurrent)"
+                var tmp = "var \(nextContainer) = \(currentContainer)"
+                tmp.append(".nestedContainer(keyedBy: CodingKeys.self, forKey: .\(single))")
+                collect.append(tmp)
+                currentContainer = nextContainer
             }
         }
         return collect
@@ -129,8 +116,12 @@ extension ParseInfo {
                 if variable.skip || (variable.isLet && variable.defaultValue != nil)  {
                     continue
                 }
-                output.append("\(editor.indentationString(level: 2))\(variable.encodeStatement())")
+                let variableStatements = variable.encodeStatements()
+                variableStatements.forEach({
+                    output.append("\(editor.indentationString(level: 2))\($0)")
+                })
             }
+            output = output.removingDuplicates()
         }
         if !override.isEmpty {
             output.append("\(editor.indentationString(level: 2))try super.encode(to: encoder)")

--- a/Xcode-Extension/CodableCommand.swift
+++ b/Xcode-Extension/CodableCommand.swift
@@ -50,6 +50,27 @@ fileprivate extension VarInfo {
         return output.joined(separator: " ")
     }
     
+//    func encodeStatement() -> String {
+//        var collect: String = ""
+//        let items = key[0].split(separator: "/")
+//        var currentContainer: String = "container"
+//        for (idx,single) in items.enumerated() {
+//            if idx == items.count - 1 {
+//                switch type {
+//                case "URL", "UIImage", "UIColor":
+//                    collect += "\(currentContainer).encode\(type)\(optional ? "IfPresent": "")(\(name), forKey: .\(single))"
+//                default:
+//                    collect +=  "\(currentContainer).encode\(optional ? "IfPregesent": "")(\(name), forKey: .\(single))"
+//                }
+//            } else {
+//                var collect = "var \(single.lowercased())Container = \(currentContainer)"
+//                collect += ".nestedContainer(keyedBy: CodingKeys.self, forKey: .\(single))\n"
+//                currentContainer = single.lowercased()
+//            }
+//        }
+//        return collect
+//    }
+    
     func encodeStatement() -> String {
         var collect = "try container"
         let items = key[0].split(separator: "/")

--- a/Xcode-Extension/CodableCommand.swift
+++ b/Xcode-Extension/CodableCommand.swift
@@ -55,7 +55,7 @@ fileprivate extension VarInfo {
         let items = key[0].split(separator: "/")
         for (idx,single) in items.enumerated() {
             if idx < items.count - 1 {
-                collect += ".nestedContainer(keyedby: CodingKeys.self, forKey: .\(single))"
+                collect += ".nestedContainer(keyedBy: CodingKeys.self, forKey: .\(single))"
             } else {
                 switch type {
                 case "URL", "UIImage", "UIColor":

--- a/Xcode-Extension/Extensions.swift
+++ b/Xcode-Extension/Extensions.swift
@@ -88,3 +88,12 @@ public func ~=<T: StringMatchable>(matchMaker: T, o: String?) -> Bool { // This 
     }
     return false
 }
+
+extension Array where Element: Hashable {
+    func removingDuplicates() -> [Element] {
+        var addedDict = [Element: Bool]()
+        return filter {
+            addedDict.updateValue(true, forKey: $0) == nil
+        }
+    }
+}

--- a/Xcode-Extension/Info.plist
+++ b/Xcode-Extension/Info.plist
@@ -42,7 +42,7 @@
 					<key>XCSourceEditorCommandIdentifier</key>
 					<string>cast</string>
 					<key>XCSourceEditorCommandName</key>
-					<string>Generate: Cast</string>
+					<string>Generate: Cast3</string>
 				</dict>
 				<dict>
 					<key>XCSourceEditorCommandClassName</key>

--- a/Xcode-Extension/Info.plist
+++ b/Xcode-Extension/Info.plist
@@ -42,7 +42,7 @@
 					<key>XCSourceEditorCommandIdentifier</key>
 					<string>cast</string>
 					<key>XCSourceEditorCommandName</key>
-					<string>Generate: Cast3</string>
+					<string>Generate: Cast</string>
 				</dict>
 				<dict>
 					<key>XCSourceEditorCommandClassName</key>


### PR DESCRIPTION
https://houzz.atlassian.net/browse/IMOB-755


ZCode fixes:

Some Swift syntax has changed since ZCode was created.

1. This variable is parsed into a single line of Codable encode statement which won't compile.
`  public var ownerName: String? //! "CreatedByUser/FullName"`

Like that:
`try container.nestedContainer(keyedby: CodingKeys.self, forKey: .CreatedByUser).encodeIfPresent(ownerName, forKey: .FullName)`

Now it generated as two separate lines:

```
var createdByUserContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .CreatedByUser)
try createdByUserContainer.encodeIfPresent(ownerName, forKey: .FullName)
```

It works for unlimited number of nested variables. Each level creates deeper container like so 'oneTwoThreeContainer'.

2. 
Replacing
```
if let dueDate = dueDate {
} 
```

with:
```
if let dueDate {
}
```

3. when generating enum cases for Codable, will generate \`extension\` instead of extension.

4. Updating keyedby with keyedBy